### PR TITLE
Notifications for health checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## Unreleased
+### Added
+- Notifications for health checks ([#18](https://github.com/scm-manager/scm-mail-plugin/pull/18))
 
 ## 2.5.0 - 2021-03-01
 ### Added

--- a/README.md
+++ b/README.md
@@ -35,6 +35,24 @@ If the browser does not start automatically, start it manually and go to [http:/
 
 In this mode each change to web files (src/main/js or src/main/webapp), should trigger reload of the browser with the made changes.
 
+## Setup Test Environment
+
+To test this plugin against an email testing tool you may use [MailHog](https://github.com/mailhog/MailHog):
+```
+docker pull mailhog/mailhog
+docker run -p 1025:1025 -p 8025:8025 mailhog/mailhog
+```
+
+Or simply use `docker-compose`:
+```
+docker-compose up
+```
+
+To connect against this container you must set the following settings in your global email configuration:
+* Host to `localhost`
+* Port to `1025`
+* From and Username to any non-empty value.
+
 ## Directory & File structure
 
 A quick look at the files and directories you'll see in an SCM-Manager project.

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 }
 
 scmPlugin {
-  scmVersion = "2.14.0"
+  scmVersion = "2.18.1-SNAPSHOT"
   displayName = "Mail"
   description = "Provides an api for sending e-mails and can be used by other plugins"
   author = "Cloudogu GmbH"

--- a/src/main/java/sonia/scm/mail/internal/HealthCheckFailedHook.java
+++ b/src/main/java/sonia/scm/mail/internal/HealthCheckFailedHook.java
@@ -60,7 +60,7 @@ public class HealthCheckFailedHook {
 
   public static final String HEALTH_CHECK_FAILED_EVENT_DISPLAY_NAME = "healthCheckFailed";
   private static final Category CATEGORY = new Category("scm-manager-core");
-  private static final Topic TOPIC_HEALTH_CHECK_FAILED = new Topic(CATEGORY, HEALTH_CHECK_FAILED_EVENT_DISPLAY_NAME);
+  static final Topic TOPIC_HEALTH_CHECK_FAILED = new Topic(CATEGORY, HEALTH_CHECK_FAILED_EVENT_DISPLAY_NAME);
   protected static final String HEALTH_CHECK_FAILED_TEMPLATE_PATH = "sonia/scm/mail/emailnotification/healthcheck_failed.mustache";
   private static final String SCM_REPOSITORY_URL_PATTERN = "{0}/repo/{1}/{2}/code/sources/";
 

--- a/src/main/java/sonia/scm/mail/internal/HealthCheckFailedHook.java
+++ b/src/main/java/sonia/scm/mail/internal/HealthCheckFailedHook.java
@@ -83,9 +83,9 @@ public class HealthCheckFailedHook {
   @Subscribe
   public void handle(HealthCheckEvent event) throws MailSendBatchException {
     if (event.getCurrentFailures() != event.getPreviousFailures() && !event.getCurrentFailures().isEmpty()) {
-      Set<String> notifiedUsers = scmConfiguration.getNotifiedUsers();
+      Set<String> emergencyContacts = scmConfiguration.getEmergencyContacts();
       MailService.EnvelopeBuilder envelopeBuilder = mailService.emailTemplateBuilder();
-      for (String user : notifiedUsers) {
+      for (String user : emergencyContacts) {
         addAddressForUser(envelopeBuilder, user);
       }
 

--- a/src/main/java/sonia/scm/mail/internal/HealthCheckFailedHook.java
+++ b/src/main/java/sonia/scm/mail/internal/HealthCheckFailedHook.java
@@ -1,0 +1,130 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.mail.internal;
+
+import com.github.legman.Subscribe;
+import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
+import sonia.scm.EagerSingleton;
+import sonia.scm.config.ScmConfiguration;
+import sonia.scm.mail.api.Category;
+import sonia.scm.mail.api.MailSendBatchException;
+import sonia.scm.mail.api.MailService;
+import sonia.scm.mail.api.MailTemplateType;
+import sonia.scm.mail.api.Topic;
+import sonia.scm.plugin.Extension;
+import sonia.scm.repository.HealthCheckEvent;
+import sonia.scm.repository.Repository;
+import sonia.scm.user.DisplayUser;
+import sonia.scm.user.UserDisplayManager;
+
+import javax.inject.Inject;
+import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.ResourceBundle;
+import java.util.Set;
+
+import static java.util.Locale.ENGLISH;
+import static java.util.Locale.GERMAN;
+import static java.util.ResourceBundle.getBundle;
+
+@Extension
+@EagerSingleton
+public class HealthCheckFailedHook {
+
+  public static final String HEALTH_CHECK_FAILED_EVENT_DISPLAY_NAME = "healthCheckFailed";
+  private static final Category CATEGORY = new Category("scm-manager-core");
+  private static final Topic TOPIC_HEALTH_CHECK_FAILED = new Topic(CATEGORY, HEALTH_CHECK_FAILED_EVENT_DISPLAY_NAME);
+  protected static final String HEALTH_CHECK_FAILED_TEMPLATE_PATH = "sonia/scm/mail/emailnotification/healthcheck_failed.mustache";
+  private static final String SCM_REPOSITORY_URL_PATTERN = "{0}/repo/{1}/{2}/code/sources/";
+
+  private static final String SUBJECT_PATTERN = "{0}/{1} {2}";
+
+  private static final Map<Locale, ResourceBundle> SUBJECT_BUNDLES = Maps
+    .asMap(new HashSet<>(Arrays.asList(ENGLISH, GERMAN)), locale -> getBundle("sonia.scm.mail.emailnotification.Subjects", locale));
+
+  private final MailService mailService;
+  private final ScmConfiguration scmConfiguration;
+  private final UserDisplayManager userDisplayManager;
+
+  @Inject
+  public HealthCheckFailedHook(MailService mailService, ScmConfiguration scmConfiguration, UserDisplayManager userDisplayManager) {
+    this.mailService = mailService;
+    this.scmConfiguration = scmConfiguration;
+    this.userDisplayManager = userDisplayManager;
+  }
+
+  @Subscribe
+  public void handle(HealthCheckEvent event) throws MailSendBatchException {
+    if (event.getCurrentFailures() != event.getPreviousFailures() && !event.getCurrentFailures().isEmpty()) {
+      Set<String> notifiedUsers = scmConfiguration.getNotifiedUsers();
+      MailService.EnvelopeBuilder envelopeBuilder = mailService.emailTemplateBuilder();
+      for (String user : notifiedUsers) {
+        addAddressForUser(envelopeBuilder, user);
+      }
+
+      envelopeBuilder
+        .onTopic(TOPIC_HEALTH_CHECK_FAILED)
+        .withSubject(getMailSubject(event, ENGLISH))
+        .withSubject(GERMAN, getMailSubject(event, GERMAN))
+        .withTemplate(HEALTH_CHECK_FAILED_TEMPLATE_PATH, MailTemplateType.MARKDOWN_HTML)
+        .andModel(getTemplateModel(event))
+        .send();
+    }
+  }
+
+  private void addAddressForUser(MailService.EnvelopeBuilder envelopeBuilder, String user) {
+    Optional<DisplayUser> displayUser = userDisplayManager.get(user);
+    if (displayUser.isPresent()) {
+      String mail = displayUser.get().getMail();
+      if (!Strings.isNullOrEmpty(mail)) {
+        envelopeBuilder.toAddress(mail);
+      }
+    }
+  }
+
+  private Map<String, Object> getTemplateModel(HealthCheckEvent event) {
+    Map<String, Object> result = Maps.newHashMap();
+    result.put("namespace", event.getRepository().getNamespace());
+    result.put("name", event.getRepository().getName());
+    result.put("link", getRepositoryLink(event.getRepository()));
+    return result;
+  }
+
+  private String getRepositoryLink(Repository repository) {
+    String baseUrl = scmConfiguration.getBaseUrl();
+    return MessageFormat.format(SCM_REPOSITORY_URL_PATTERN, baseUrl, repository.getNamespace(), repository.getName());
+  }
+
+  private String getMailSubject(HealthCheckEvent event, Locale locale) {
+    Repository repository = event.getRepository();
+    String displayEventName = SUBJECT_BUNDLES.get(locale).getString(HEALTH_CHECK_FAILED_EVENT_DISPLAY_NAME);
+    return MessageFormat.format(SUBJECT_PATTERN, repository.getNamespace(), repository.getName(), displayEventName);
+  }
+}

--- a/src/main/java/sonia/scm/mail/internal/HealthCheckTopics.java
+++ b/src/main/java/sonia/scm/mail/internal/HealthCheckTopics.java
@@ -1,0 +1,45 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.mail.internal;
+
+import sonia.scm.mail.api.Topic;
+import sonia.scm.mail.api.TopicProvider;
+import sonia.scm.plugin.Extension;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import static sonia.scm.mail.internal.HealthCheckFailedHook.TOPIC_HEALTH_CHECK_FAILED;
+
+@Extension
+public class HealthCheckTopics implements TopicProvider {
+
+  @Override
+  public Collection<Topic> topics() {
+    return Collections.singletonList(
+      TOPIC_HEALTH_CHECK_FAILED
+    );
+  }
+}

--- a/src/main/resources/locales/de/plugins.json
+++ b/src/main/resources/locales/de/plugins.json
@@ -27,7 +27,7 @@
     },
     "topics": {
       "header": "Abonnierte Kanäle",
-      "helpText": "Zu den ausgewählten Themen werden Benachrichtigungen per Mail verschickt."
+      "helpText": "Zu den ausgewählten Themen können Benachrichtigungen per Mail verschickt werden. Eine gesetzte Checkbox allein impliziert allerdings nicht, dass man für das jeweilige Event benachrichtigt wird. Dies ist als eine Opt-Out Option anzusehen."
     }
   },
   "mailTopics": {

--- a/src/main/resources/locales/de/plugins.json
+++ b/src/main/resources/locales/de/plugins.json
@@ -30,6 +30,15 @@
       "helpText": "Zu den ausgewählten Themen werden Benachrichtigungen per Mail verschickt."
     }
   },
+  "mailTopics": {
+    "scm-manager-core": {
+      "label": "SCM-Manager Core",
+      "healthCheckFailed": {
+        "label": "Fehlgeschlagene Health Checks",
+        "helpText": "Mails bei fehlgeschlagenen Repository Health Checks."
+      }
+    }
+  },
   "permissions": {
     "configuration": {
       "read,write": {

--- a/src/main/resources/locales/en/plugins.json
+++ b/src/main/resources/locales/en/plugins.json
@@ -30,6 +30,15 @@
       "helpText": "On the selected topics, email notifications will be sent."
     }
   },
+  "mailTopics": {
+    "scm-manager-core": {
+      "label": "SCM-Manager Core",
+      "healthCheckFailed": {
+        "label": "Failed health checks",
+        "helpText": "Mails on failed repository health checks."
+      }
+    }
+  },
   "permissions": {
     "configuration": {
       "read,write": {

--- a/src/main/resources/locales/en/plugins.json
+++ b/src/main/resources/locales/en/plugins.json
@@ -27,7 +27,7 @@
     },
     "topics": {
       "header": "Subscribed Topics",
-      "helpText": "On the selected topics, email notifications will be sent."
+      "helpText": "On the selected topics, email notifications can be sent. However, a check mark alone does not imply that you will be notified for the respective event. This is to be seen as an opt-out option."
     }
   },
   "mailTopics": {

--- a/src/main/resources/sonia/scm/mail/emailnotification/Subjects_de.properties
+++ b/src/main/resources/sonia/scm/mail/emailnotification/Subjects_de.properties
@@ -24,4 +24,5 @@
 
 importSuccess = Repository Import erfolgreich
 importFailed = Repository Import fehlgeschlagen
+healthCheckFailed = Repository Health Check fehlgeschlagen
 

--- a/src/main/resources/sonia/scm/mail/emailnotification/Subjects_en.properties
+++ b/src/main/resources/sonia/scm/mail/emailnotification/Subjects_en.properties
@@ -24,3 +24,4 @@
 
 importSuccess = Repository import successful
 importFailed = Repository import failed
+healthCheckFailed = Repository Health Check failed

--- a/src/main/resources/sonia/scm/mail/emailnotification/healthcheck_failed.mustache
+++ b/src/main/resources/sonia/scm/mail/emailnotification/healthcheck_failed.mustache
@@ -1,0 +1,3 @@
+# Repository Health Check failed
+
+The repository health check failed for {{namespace}}/{{name}}.

--- a/src/main/resources/sonia/scm/mail/emailnotification/healthcheck_failed.mustache
+++ b/src/main/resources/sonia/scm/mail/emailnotification/healthcheck_failed.mustache
@@ -1,3 +1,3 @@
 # Repository Health Check failed
 
-The repository health check failed for {{namespace}}/{{name}}.
+The repository health check failed for [{{namespace}}/{{name}}]({{link}}).

--- a/src/main/resources/sonia/scm/mail/emailnotification/healthcheck_failed_de.mustache
+++ b/src/main/resources/sonia/scm/mail/emailnotification/healthcheck_failed_de.mustache
@@ -1,0 +1,3 @@
+# Repository Health Check fehlgeschlagen
+
+Der Repository Health Check für {{namespace}}/{{name}} ist fehlgeschlagen.

--- a/src/main/resources/sonia/scm/mail/emailnotification/healthcheck_failed_de.mustache
+++ b/src/main/resources/sonia/scm/mail/emailnotification/healthcheck_failed_de.mustache
@@ -1,3 +1,3 @@
 # Repository Health Check fehlgeschlagen
 
-Der Repository Health Check für {{namespace}}/{{name}} ist fehlgeschlagen.
+Der Repository Health Check für [{{namespace}}/{{name}}}({{link}}) ist fehlgeschlagen.

--- a/src/test/java/sonia/scm/mail/internal/HealthCheckFailedHookTest.java
+++ b/src/test/java/sonia/scm/mail/internal/HealthCheckFailedHookTest.java
@@ -84,7 +84,7 @@ public class HealthCheckFailedHookTest {
     when(envelopeBuilder.withSubject(anyString())).thenReturn(subjectBuilder);
     when(subjectBuilder.withTemplate(anyString(), any(MailTemplateType.class))).thenReturn(templateBuilder);
     when(templateBuilder.andModel(any())).thenReturn(mailBuilder);
-    when(scmConfiguration.getNotifiedUsers()).thenReturn(ImmutableSet.of("name"));
+    when(scmConfiguration.getEmergencyContacts()).thenReturn(ImmutableSet.of("name"));
     when(userDisplayManager.get("name")).thenReturn(of(DisplayUser.from(new User("name", "name", "name@mail.com"))));
 
     HealthCheckEvent healthCheckEvent = new HealthCheckEvent(REPOSITORY, Collections.emptyList(), Collections.singletonList(healthCheckFailure));

--- a/src/test/java/sonia/scm/mail/internal/HealthCheckFailedHookTest.java
+++ b/src/test/java/sonia/scm/mail/internal/HealthCheckFailedHookTest.java
@@ -1,0 +1,103 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.mail.internal;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sonia.scm.config.ScmConfiguration;
+import sonia.scm.mail.api.MailSendBatchException;
+import sonia.scm.mail.api.MailService;
+import sonia.scm.mail.api.MailTemplateType;
+import sonia.scm.repository.HealthCheckEvent;
+import sonia.scm.repository.HealthCheckFailure;
+import sonia.scm.repository.Repository;
+import sonia.scm.user.DisplayUser;
+import sonia.scm.user.User;
+import sonia.scm.user.UserDisplayManager;
+
+import java.util.Collections;
+
+import static java.util.Optional.of;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class HealthCheckFailedHookTest {
+
+  private final Repository REPOSITORY = new Repository("1", "git", "undermore", "repo");
+  private final HealthCheckFailure healthCheckFailure = new HealthCheckFailure("1", "vogons", "met vogons");
+
+  @Mock
+  private MailService mailService;
+
+  @Mock
+  private ScmConfiguration scmConfiguration;
+
+  @Mock
+  private UserDisplayManager userDisplayManager;
+
+  @Mock(answer = Answers.RETURNS_SELF)
+  private MailService.EnvelopeBuilder envelopeBuilder;
+  @Mock(answer = Answers.RETURNS_SELF)
+  private MailService.SubjectBuilder subjectBuilder;
+  @Mock(answer = Answers.RETURNS_SELF)
+  private MailService.TemplateBuilder templateBuilder;
+  @Mock(answer = Answers.RETURNS_SELF)
+  private MailService.MailBuilder mailBuilder;
+
+  @InjectMocks
+  private HealthCheckFailedHook healthCheckFailedHook;
+
+  @Test
+  void shouldSendMailForHealthChange() throws MailSendBatchException {
+    when(mailService.emailTemplateBuilder()).thenReturn(envelopeBuilder);
+    when(envelopeBuilder.withSubject(anyString())).thenReturn(subjectBuilder);
+    when(subjectBuilder.withTemplate(anyString(), any(MailTemplateType.class))).thenReturn(templateBuilder);
+    when(templateBuilder.andModel(any())).thenReturn(mailBuilder);
+    when(scmConfiguration.getNotifiedUsers()).thenReturn(ImmutableSet.of("name"));
+    when(userDisplayManager.get("name")).thenReturn(of(DisplayUser.from(new User("name", "name", "name@mail.com"))));
+
+    HealthCheckEvent healthCheckEvent = new HealthCheckEvent(REPOSITORY, Collections.emptyList(), Collections.singletonList(healthCheckFailure));
+    healthCheckFailedHook.handle(healthCheckEvent);
+
+    verify(mailService).emailTemplateBuilder();
+  }
+
+  @Test
+  void shouldNotSendMail() throws MailSendBatchException {
+    HealthCheckEvent healthCheckEvent = new HealthCheckEvent(REPOSITORY, Collections.emptyList(), Collections.emptyList());
+    healthCheckFailedHook.handle(healthCheckEvent);
+
+    verify(mailService, never()).emailTemplateBuilder();
+  }
+}


### PR DESCRIPTION
## Proposed changes

Notified users configured in the SCM-Manager receive notifications in form of e-mails and toast messages when health checks fail.

### Your checklist for this pull request

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [ ] New ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
